### PR TITLE
Fix login redirect for React client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.phpunit.cache
 /node_modules
+/frontend/node_modules
 /public/build
 /public/hot
 /public/storage

--- a/app/Services/AuthService.php
+++ b/app/Services/AuthService.php
@@ -16,12 +16,16 @@ class AuthService
 //    return back()->withErrors(['username'=>'Грешно потребителско име или парола.']);
 //}
 
-    public function redirectByRole(string $role){
-        return match($role){
-            'administrator' =>redirect()->route('administrator_dashboard'),
-            'teacher' => redirect()->route('teacher_dashboard'),
-            'student' => redirect()->route('exams'),
-            default => redirect()->route('login'),
+    public function redirectByRole(string $role)
+    {
+        // Return the target route URL instead of a RedirectResponse so
+        // that callers can handle the navigation (e.g. in React) without
+        // receiving a serialized redirect object.
+        return match ($role) {
+            'administrator' => route('admin.dashboard', [], false),
+            'teacher'       => route('teacher_dashboard', [], false),
+            'student'       => route('exams', [], false),
+            default         => route('login', [], false),
         };
     }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,8 @@
         "bootstrap": "^5.3.8",
         "font-awesome": "^4.7.0",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^6.30.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -694,6 +695,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2099,6 +2109,38 @@
       },
       "peerDependencies": {
         "react": "^19.1.1"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/resolve-from": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
     "bootstrap": "^5.3.8",
     "font-awesome": "^4.7.0",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^6.30.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,15 +1,19 @@
 
 import React from 'react';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Login from './Login';
+import Exams from './Exams';
 import 'bootstrap/dist/css/bootstrap.min.css';
 
 function App() {
     return (
-        <div className="App">
-            <Login />
-        </div>
+        <BrowserRouter>
+            <Routes>
+                <Route path="/" element={<Login />} />
+                <Route path="/student/exams" element={<Exams />} />
+            </Routes>
+        </BrowserRouter>
     );
 }
 
-
-export default App
+export default App;

--- a/frontend/src/Exams.jsx
+++ b/frontend/src/Exams.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const Exams = () => (
+  <div className="p-4">
+    <h1>Страница с изпити</h1>
+    <p>Това е примерна React страница след успешен вход.</p>
+  </div>
+);
+
+export default Exams;

--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faUser, faLock, faEye, faEyeSlash, faSignInAlt } from '@fortawesome/free-solid-svg-icons';
 import './Login.css';
-import universityLogo from './assets/university-logo.png';
 import logo from './assets/university-logo.png';
 
 
@@ -12,26 +12,30 @@ const Login = () => {
     const [showPassword, setShowPassword] = useState(false);
     const [errors, setErrors] = useState([]);
 
+    const navigate = useNavigate();
+
     const handleSubmit = async (e) => {
         e.preventDefault();
         setErrors([]);
-        try{
-            const response=await fetch('/login',{
-                method:'POST',
-                headers:{
+        try {
+            const response = await fetch('/login', {
+                method: 'POST',
+                headers: {
                     'Content-Type': 'application/json',
                     'Accept': 'application/json',
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content
-            },body: JSON.stringify({username,password})
+                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+                },
+                body: JSON.stringify({ username, password }),
             });
-            const data=await response.json();
-            if(response.ok){
-                window.location.href=data.redirect;
-            }else{
-                setErrors([data.message])
+            const data = await response.json();
+            if (response.ok) {
+                const url = new URL(data.redirect, window.location.origin);
+                navigate(url.pathname);
+            } else {
+                setErrors([data.message]);
             }
-        }catch (error){
-            setErrors([data.message]);
+        } catch (error) {
+            setErrors([error.message]);
         }
         // Валидация
         const newErrors = [];


### PR DESCRIPTION
## Summary
- return direct route URLs in `AuthService` for React navigation
- handle fetch errors correctly in React login form
- add React exams page and client-side routing for post-login navigation

## Testing
- `npm --prefix frontend run lint`
- `vendor/bin/phpunit` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e20506fc8325b9df10bc2ac9718e